### PR TITLE
Fix build by using semver for dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "babel": "latest",
-    "mocha": "latest",
-    "should": "latest",
-    "source-map-support": "latest"
+    "babel": "^5.8.34",
+    "mocha": "^2.3.4",
+    "should": "^7.1.1",
+    "source-map-support": "^0.3.3"
   },
   "main": "./lib",
   "files": [


### PR DESCRIPTION
I just looked at the library and haven't done much with it, but I really love your simple introduction and tutorial to parser combinators! Most other tutorials I've seen skip too much or immediately jump off the deep end into unfamiliar jargon.

Anyway I noticed that building the library is broken if you install the dependencies right now and try to build. Your package.json specifies that any version of the dependencies is good, but babel and possibly the others have released updates with incompatible APIs since packrattle was last built. Many packages on NPM including each of the dependencies follow the [semver](http://semver.org/) convention, so in this pull request I've modified the package.json to pin each of the dependencies to the latest version of each that's compatible with what I figure the versions were that you last built with. This fixes packrattle to be buildable from a fresh install now. The unit tests all pass.